### PR TITLE
* UPD: [Render] Add magic number to L_clr intensity [.peak]

### DIFF
--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_accum_spot.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_accum_spot.cpp
@@ -349,7 +349,8 @@ void CRenderTarget::accum_volumetric_lv(light* L)
 	L_clr.mul(L->m_volumetric_intensity);
 	L_clr.mul(L->m_volumetric_distance);
 	L_clr.mul(L->get_LOD());
-
+	L_clr.mul(0.3); //LV: another magic number, but since gamma has 9125801250808+1 magic numbers, it doesn't matter.
+	
 	L_pos.set(L->position);
 	L_dir.set(L->direction);
 	L_dir.normalize();


### PR DESCRIPTION
because gamma players can't read, and they're too lazy to solve problems on their own.