### PR TITLE
Fix items destroyed in inventory rendering for one frame at the owner (the "mag flash")

### DIFF
--- a/src/xrEngine/xr_object.cpp
+++ b/src/xrEngine/xr_object.cpp
@@ -296,6 +296,9 @@ BOOL CObject::net_Spawn(CSE_Abstract* data)
 void CObject::net_Destroy()
 {
 	VERIFY(getDestroy());
+	// objects are pooled and reused (ObjectPool.create/destroy) - never let
+	// the pre-destroy flag leak into the next object recycled from the pool
+	SetTmpPreDestroy(FALSE);
 	xr_delete(collidable.model);
 	if (register_schedule())
 		shedule_unregister();

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -757,6 +757,16 @@ void			CGameObject::dbg_DrawSkeleton	()
 
 void CGameObject::renderable_Render()
 {
+	// Objects being destroyed must not render. A parented item destroyed via
+	// server release (e.g. a consumed magazine) is first rejected - detached
+	// at the owner's position - and rendered until the destroy event lands
+	// (which can be one or more frames later); without this it flashes next
+	// to the player. GetTmpPreDestroy covers the reject->destroy gap (set
+	// synchronously when the reject is processed), getDestroy covers the
+	// destroy-queued state.
+	if (getDestroy() || GetTmpPreDestroy())
+		return;
+
 	inherited::renderable_Render();
 	::Render->set_Transform(&XFORM());
 	::Render->add_Visual(Visual());

--- a/src/xrGame/attachable_item.cpp
+++ b/src/xrGame/attachable_item.cpp
@@ -67,6 +67,14 @@ void CAttachableItem::OnH_A_Chield()
 
 void CAttachableItem::renderable_Render()
 {
+	// Don't render items that are being destroyed: a parented item destroyed
+	// via server release is rejected (detached at the owner's position) and
+	// only actually removed when the destroy event lands - this unguarded
+	// submission path made e.g. consumed magazine items flash for a frame
+	// next to the player after every magazine-system reload.
+	if (object().getDestroy() || object().GetTmpPreDestroy())
+		return;
+
 	::Render->set_Transform(&object().XFORM());
 	::Render->add_Visual(object().Visual());
 }

--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -208,6 +208,18 @@ void CInventoryItem::OnH_B_Independent(bool just_before_destroy)
 {
 	UpdateXForm();
 	m_ItemCurrPlace.type = eItemPlaceUndefined;
+
+	// An item detached only because it is about to be destroyed (e.g. a
+	// consumed magazine released by script while parented to the actor) must
+	// not become visible for its final frame: UpdateXForm just placed it at
+	// the owner's position, and the destroy only lands on the next update -
+	// without this it renders for exactly one frame next to the player
+	// (the infamous "mag flash" after every magazine-system reload).
+	if (just_before_destroy)
+	{
+		object().setVisible(FALSE);
+		object().setEnabled(FALSE);
+	}
 }
 
 void CInventoryItem::OnH_A_Independent()

--- a/src/xrGame/physic_item.cpp
+++ b/src/xrGame/physic_item.cpp
@@ -59,11 +59,22 @@ void CPhysicItem::OnH_B_Independent(bool just_before_destroy)
 	if (m_ready_to_destroy)
 		return;
 
+	// An item detached only because it is about to be destroyed (e.g. a
+	// consumed magazine released by script while parented to the actor) must
+	// NOT be made visible: the destroy lands on the next update, so showing
+	// it here renders it for exactly one frame at the owner's position
+	// (the "mag flash" seen after every magazine-system reload).
+	if (just_before_destroy)
+	{
+		setVisible(FALSE);
+		setEnabled(FALSE);
+		return;
+	}
+
 	setVisible(TRUE);
 	setEnabled(TRUE);
 
-	if (!just_before_destroy)
-		activate_physic_shell();
+	activate_physic_shell();
 }
 
 void CPhysicItem::OnH_B_Chield()


### PR DESCRIPTION
## The bug

When a script destroys an item that is inside someone's inventory (e.g. `alife_release_id` on a consumed magazine — which GAMMA Mags Reloaded / Anomaly Magazines do on **every reload**), the engine processes it as reject-then-destroy: the item is detached at the owner's position (`UpdateXForm`), made visible, and the destroy event only lands one or more frames later. During that gap the item is rendered — a one-frame "item flash" next to the player.

With magazine mods this is visible after every reload of every gun: the consumed mag's world model flashes beside the weapon. Repro: any magazine-system install, reload while frame-stepping, or simply delay the release by 5 s in Lua — the flash moves with it.

## The fix (5 small changes, one commit)

- **physic_item.cpp** — `OnH_B_Independent` used `just_before_destroy` only to skip the physics shell but still called `setVisible(TRUE)` unconditionally; now the item is hidden/disabled in that case.
- **inventory_item.cpp** — same at the inventory layer (mirrors what `eatable_item.cpp` already does for consumed food).
- **GameObject.cpp** — `setVisible` alone doesn't gate world rendering, so `renderable_Render` now early-returns on `getDestroy() || GetTmpPreDestroy()`. `GetTmpPreDestroy` is set synchronously when the reject event is processed, covering the reject→destroy gap.
- **attachable_item.cpp** — `CAttachableItem::renderable_Render` is a second, unguarded submission path used by `II_ATTCH` items (which is what magazine items are); same guard added. Without this the other fixes are defeated for exactly the items that matter.
- **xr_object.cpp** — `net_Destroy` clears the pre-destroy flag: client objects are pooled/reused (`ObjectPool`), and a stale flag leaked into recycled objects, leaving them permanently invisible.

Normal drops/trades are unaffected (`just_before_destroy` / `GetTmpPreDestroy` are only true when the reject precedes destruction — verified against all four senders in `Actor_Events.cpp`, `ai_stalker_events.cpp`, `ai_trader.cpp`, `Car.cpp`).

Tested in GAMMA on this fork's engine: the flash is gone on every magazine-system gun, item pickup/drop/trade unaffected.
